### PR TITLE
Fixed not picking up the generation comment if the var has an export …

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -44,12 +44,17 @@ function extractAllObjects(program: ts.Program, file: ts.SourceFile): ObjectDict
         return result;
     }
     let foundVariables: ObjectDictionary = {};
+
+    function hasTrivia(n: ts.Node) {
+        let triviaWidth = n.getLeadingTriviaWidth()
+        let sourceText = n.getSourceFile().text;
+        let trivia = sourceText.substr(n.getFullStart(), triviaWidth);
+        return trivia.indexOf("Generate_Union") != -1
+    }
+
     function visit(node: ts.Node, context: ts.TransformationContext): ts.Node {
         if(ts.isVariableDeclarationList(node)) {
-            let triviaWidth = node.getLeadingTriviaWidth()
-            let sourceText = node.getSourceFile().text;
-            let trivia = sourceText.substr(node.getFullStart(), triviaWidth);
-            if(trivia.indexOf("Generate_Union") != -1) // Will generate fro variables with a comment Generate_Union above them
+            if(hasTrivia(node) || hasTrivia(node.parent)) // Will generate fro variables with a comment Generate_Union above them
             {
                 for(let declaration of node.declarations) {
                     if(declaration.initializer && ts.isObjectLiteralExpression(declaration.initializer)){

--- a/input.ts
+++ b/input.ts
@@ -1,3 +1,4 @@
+/*Generate_Union*/
 export const colors = {
   accent: '#f90',
   primary: {

--- a/output.ts
+++ b/output.ts
@@ -1,0 +1,1 @@
+type colorsPaths = "accent" | "primary.active" | "primary.inactive";


### PR DESCRIPTION
There were two issues. 

1. I did not know if your files will contain other declaration so to enable the generation a comment must appear above the variable /*Generate_Union*/
2. For exported variables, this comment is not found directly on the variable list but rather on the parent, and so it was not getting picked up. Fixed it to check for the comment directly on the node or on the parent node.

If you want to generate for all variables in the input file just remove the  if on line 57:

```
if(hasTrivia(node) || hasTrivia(node.parent))
```
